### PR TITLE
Accessibility Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Github = https://github.com/GreenInfo-Network/MapLibre-Control-Credits/
 const credits = new MaplibreControlCredits({
     linkUrl: "https://greeninfo.org/",
     imageUrl: "./greeninfo.png",
+    imageAlt: "Green Info",
 });
 MAP.addControl(credits, 'bottom-right');
 ```
@@ -21,7 +22,7 @@ Constructor parameters:
 
 * `linkUrl` -- The hyperlink will have this URL as its `href`
 * `imageUrl` -- The URL of the image to display. Can be relative, absolute, or even inline data.
-
+* `imageAlt` -- The text alternative of the image, which also serves as link text in this case. Needed to make the image and link accessible to blind and visually impaired people, also gets displayed when the image fails to load.
 
 This control is intentionally minimal and lightweight, since the needs for custom behaviors vary so widely. You can adjust the CSS in **maplibre-control-credits.css** to adjust the size of the image, or to apply CSS transforms if necessary..
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
         const credits = new MaplibreControlCredits({
             linkUrl: "https://greeninfo.org/",
             imageUrl: "./greeninfo.png",
+            imageAlt: "Green Info",
         });
         MAP.addControl(credits, 'bottom-right');
     });

--- a/maplibre-control-credits.css
+++ b/maplibre-control-credits.css
@@ -8,3 +8,16 @@ div.maplibre-control-credits a {
 div.maplibre-control-credits img {
     display: block;
 }
+
+/* Add a 2px outline to the image on :focus */
+/* Needs to be on the img in this case because safari & chrome rendering bug */
+div.maplibre-control-credits a:focus img {
+  outline: 2px solid black;
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* Remove the focus outline from links that have an image */
+div.maplibre-control-credits a:focus:has(img){
+  outline: none;
+}

--- a/maplibre-control-credits.js
+++ b/maplibre-control-credits.js
@@ -11,7 +11,7 @@ class MaplibreControlCredits {
         const div = document.createElement('div');
         div.className = 'mapboxgl-ctrl mapboxgl-ctrl-group maplibre-control-credits';
 
-        div.innerHTML = `<a href="${this.options.linkUrl}" target="_blank"><img src="${this.options.imageUrl}" alt="${this.options.imageAlt}" /></a>`;
+        div.innerHTML = `<a href="${this.options.linkUrl}"><img src="${this.options.imageUrl}" alt="${this.options.imageAlt}" /></a>`;
 
         return div;
     }

--- a/maplibre-control-credits.js
+++ b/maplibre-control-credits.js
@@ -3,6 +3,7 @@ class MaplibreControlCredits {
         this.options = Object.assign({
             linkUrl: "/",
             imageUrl: "//:0",
+            imageAlt: "",
         }, options);
     }
 
@@ -10,7 +11,7 @@ class MaplibreControlCredits {
         const div = document.createElement('div');
         div.className = 'mapboxgl-ctrl mapboxgl-ctrl-group maplibre-control-credits';
 
-        div.innerHTML = `<a href="${this.options.linkUrl}" target="_blank"><img src="${this.options.imageUrl}" alt="" /></a>`;
+        div.innerHTML = `<a href="${this.options.linkUrl}" target="_blank"><img src="${this.options.imageUrl}" alt="${this.options.imageAlt}" /></a>`;
 
         return div;
     }


### PR DESCRIPTION
## Review
### Links
- [X] Regular link text is at least 4.5:1 against the background.
- [X] Large link text is at least 3:1 against the background.
- [X] More than just color is used to distinguish links from surrounding text. Contrast higher than 3:1 against surrounding text counts as more than just color.
- [ ] ⛔️ **The link text describes its purpose sufficiently.** → Added in PR.
- [X] The link has a focus indicator on `:focus`.
    - [X] WCAG 2.1 requires there is an indicator.
    - [X] Sufficient: Using the default user agent focus indicator.
    - [ ] **⛔️ Recommended: The indicator has at least 3:1 contrast between focused and unfocused state.** → Added in PR. 
    - [ ] **⛔️ Recommended: The indicator has at least 3:1 contrast against the background.** → Added in PR. 
    - [ ] **⛔️ Recommended: The indicator is at least 2px in thickness.** → Added in PR. 
- [ ] **⛔️ Links that open in new tabs or start a download have an indication of their behavior.** → Added in PR. 

### Images
- [ ] ⛔️ **Images are described with `alt="..."` text** → Added in PR.

### Comments
- I assume the image used in this demo is not necessarily the same as would be used in production, but I recommend to upload an svg (or higher quality png) to avoid pixelation of the logo. Since the image is the only link label and the only way the credits are communicated (not written in text format anywhere) it's good that they're sharp and well readable, current one is a bit pixelated.

## Changed
### Added alt text support on the credits image.
```
<img src="${this.options.imageUrl}" alt="${this.options.imageAlt}" />
```
Previously the credits image had an empty `alt`, meaning screen readers did not announce it as all (treated it like a decorative image). In this case the image is not decorative, it serves a purpose: adding credits on the map. Additionally, since the image is the only content inside the `<a>`, it also serves as link text. Without a text alternative or a visually hidden link label, the link is unlabelled for screen reader users.

Added the `imageAlt` attribute, which is an empty string by default (leading to empty alt text, aka decorative image when not set), and is set to `Green Info` in the html file. Screen readers will announce the link along the lines of: `"Green Info, link"`.

### Links now open in the same tab.
Generally it's not recommended to automatically open links in a new tab, therefor removed.

However, it can sometimes be useful that links open in a new tab, depending on how they're used. For example, if the user can move/zoom and set filters on the map, but the filters and position get forgotten about after moving to the credits page and using the back button to get back to the map, then it could be argued opening the link in the same tab is needed to not disturb an important flow when accidentally pressing the link. 

In that case, an indication of the behavior is needed, for example something along the lines of `(new tab)` or an icon with `opens in new tab` as alt text can be added to the link.

For now I opted to remove it, because the other option (adding the label) would require either change in design to add it visually in text format or a visually hidden label that explains it to add inside the link. Either way would require an extra string to be maintained in internationalisation etc. If it turns out the open-in-new-tab is needed for usability, we can bring the `target="_blank"` back and the extra code and labels for it, but otherwise it's better to stick to the default behavior.

### Custom darker and thicker focus outlines
Focus outlines are mainly useful for keyboard users, who need to know which element has keyboard focus. It can also be useful for people with cognitive disabilities to follow along on the page. While for WCAG 2.1 the default user agent outline is sufficient, it's recommended to add a custom border or outline that is at least:
- 2px wide
- 3:1 contrast against the adjacent colors 
- 3:1 contrast agains the "previous" colors (between the focused and unfocused state)
People who use keyboard navigation may have vision impairments or cognitive impairments as well, which means that the focus indicator should be visible and noticeable enough to be useful. It needs to stand out against the background and adjacent elements, and the change between the focused and unfocused state needs to be large enough. 

Added a `2px solid black` border when the credits receive `:focus`.
In Safari & Chrome there was a bug where the `:focus` styling did not show when added on the `<a>` (wrapped in the floating `<div>`) with an `<img>` as only content inside. So in this case the focus styling was added on the `a:focus img`.